### PR TITLE
Update nightly_build_and_test_stats.groovy

### DIFF
--- a/tools/nightly_build_and_test_stats.groovy
+++ b/tools/nightly_build_and_test_stats.groovy
@@ -179,7 +179,7 @@ node ("master") {
     echo "======> Overall Nightly Build & Test Success Rating = ${overallNightlySuccessRating} %"
 
     // Slack message:
-    slackSend(channel: slackChannel, color: 'good', message: 'AdoptOpenJDK Jenkins Nightly Build & Test Pipeline Success Rating: '+overallNightlySuccessRating+' %')
+    slackSend(channel: slackChannel, color: 'good', message: 'AdoptOpenJDK Jenkins Nightly Build & Test Pipeline Success Rating: '+overallNightlySuccessRating+' % (derived from '+totalBuildJobs+' at '+nightlyBuildSuccessRating.intValue()+' %, '+totalTestJobs+' at '+nightlyTestSuccessRating.intValue()+' %)')
   }
 }
 


### PR DESCRIPTION
added "(derived from '+totalBuildJobs+' at '+nightlyBuildSuccessRating.intValue()+' %, '+totalTestJobs+' at '+nightlyTestSuccessRating.intValue()+' %)" to Slack message
I realize the hyperlink to the Jenkins Job is still missing - could you please point me to how i'd do that? Thank you!